### PR TITLE
Circle CI config validation hook does not run if in CI

### DIFF
--- a/hooks/circleci-config-validate.sh
+++ b/hooks/circleci-config-validate.sh
@@ -4,6 +4,11 @@ set -e
 readonly DEBUG=${DEBUG:-unset}
 [[ $DEBUG != unset ]] && set -x
 
+# do not run in Circle CI
+if [[ -n $CIRCLECI ]]; then
+	return
+fi
+
 # assert the circleci command exists
 if ! [ -x "$(command -v circleci)" ]; then
     echo 'circleci command not found'

--- a/hooks/circleci-config-validate.sh
+++ b/hooks/circleci-config-validate.sh
@@ -6,7 +6,7 @@ readonly DEBUG=${DEBUG:-unset}
 
 # do not run in Circle CI
 if [[ -n $CIRCLECI ]]; then
-	return
+	exit 0
 fi
 
 # assert the circleci command exists


### PR DESCRIPTION
- [x] Have you followed our [contributors guide][contributing]?
- [x] Why is this change being made? What value does it add?
Allows you to run the same pre-commit config containing the validate circle hook in CircleCI - currently this errors.
- [x] Did you include automated testing where possible?
- [x] How can this be verified by a human? Describe how to test this.
I ran pre-commit locally and in CircleCI and it worked in both
