### PR TITLE
Restrict shellcheck and shfmt to supported shells

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -49,6 +49,7 @@
   entry: hooks/shellcheck.sh
   language: script
   types: [shell]
+  exclude_types: [awk, csh, expect, perl, python, ruby, tcsh, zsh]
   args: [-e, SC1091]
   additional_dependencies: [shellcheck]
 
@@ -57,5 +58,6 @@
   language: script
   entry: hooks/shfmt.sh
   types: [shell]
+  exclude_types: [awk, csh, expect, perl, python, ruby, tcsh, zsh]
   args: ['-l', '-i', '2', '-ci']
   additional_dependencies: [shfmt]


### PR DESCRIPTION
shmft and shellcheck don't work on zsh and some others shells.

[based on goodShells ](https://github.com/koalaman/shellcheck/blob/master/src/ShellCheck/Parser.hs#L3236)

Works with identify v1.5.0