### PR TITLE
remove additional_dependencies definition for checks

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -51,7 +51,6 @@
   types: [shell]
   exclude_types: [csh, perl, python, ruby, tcsh, zsh]
   args: [-e, SC1091]
-  additional_dependencies: [shellcheck]
 
 - id: shfmt
   name: Check shell style with shfmt
@@ -60,4 +59,3 @@
   types: [shell]
   exclude_types: [csh, perl, python, ruby, tcsh, zsh]
   args: ['-l', '-i', '2', '-ci']
-  additional_dependencies: [shfmt]


### PR DESCRIPTION
This will fix #8 as a new validation for additional_dependencies / language has been added in pre-commit 2.10.0 with https://github.com/pre-commit/pre-commit/pull/1771