### PR TITLE
Add support for passing additional arguments to the CircleCI Validation hook

### DIFF
--- a/hooks/circleci-config-validate.sh
+++ b/hooks/circleci-config-validate.sh
@@ -17,7 +17,7 @@ if [[ -z $CIRCLECI ]]; then
 	[ -f /dev/tty ] && exec /dev/tty
 
 	# If validation fails, tell Git to stop and provide error message. Otherwise, continue.
-	if ! msg=$(circleci config validate); then
+	if ! msg=$(circleci config validate "$@"); then
 		echo "CircleCI Configuration Failed Validation."
 		echo "$msg"
 		exit 1


### PR DESCRIPTION
Adds support for passing additional args to the `circleci-config-validate` hook to allow people to pass args, such as the organizational arg, to the CircleCI CLI Tool

```
  - repo: https://github.com/syntaqx/git-hooks
    rev: <tbd>
    hooks:
      - id: circleci-config-validate
        args: [ "-o", "github/myorg" ]
```